### PR TITLE
Store return code as an attribute in ToolsHandler context manager.

### DIFF
--- a/mbed_tools_lib/logging.py
+++ b/mbed_tools_lib/logging.py
@@ -35,6 +35,7 @@ class MbedToolsHandler:
         """Keep track of the logger to use and whether or not a traceback should be generated."""
         self._logger = logger
         self._traceback = traceback
+        self.return_code = 0
 
     def __enter__(self) -> "MbedToolsHandler":
         """Return the Context Manager."""
@@ -51,7 +52,11 @@ class MbedToolsHandler:
             error_msg = _exception_message(cast(BaseException, exc_value), logging.root.level, self._traceback)
             self._logger.error(error_msg, exc_info=self._traceback)
             # Do not propagate exceptions derived from ToolsError
+            self.return_code = 1
             return True
+
+        if not exc_type:
+            self.return_code = 0
 
         # Propagate all other exceptions
         return False

--- a/news/20200507.bugfix
+++ b/news/20200507.bugfix
@@ -1,0 +1,1 @@
+Store return code as an attribute in ToolsHandler context manager.


### PR DESCRIPTION
### Description

This is needed so we can exit with the correct code in the mbed-tools cli.

This is a workaround as python eats the output of `__exit__` making it unavailable in the execution context.

### Test Coverage

- [x]  This change is covered by existing or additional automated tests.
- [ ]  Manual testing has been performed (and evidence provided) as automated testing was not feasible.
- [ ]  Additional tests are not required for this change (e.g. documentation update).
